### PR TITLE
Feature/dockerize patient service

### DIFF
--- a/patient-service/Dockerfile
+++ b/patient-service/Dockerfile
@@ -1,0 +1,21 @@
+FROM maven:3.9.9-eclipse-temurin-23 AS builder
+
+WORKDIR /app
+
+COPY pom.xml .
+
+RUN mvn dependency:go-offline -B
+
+COPY src ./src
+
+RUN mvn clean package
+
+FROM openjdk:23-jdk AS runner
+
+WORKDIR /app
+
+COPY --from=builder ./app/target/patient-service-0.0.1-SNAPSHOT.jar ./app.jar
+
+EXPOSE 4000
+
+ENTRYPOINT ["java", "-jar", "app.jar"]

--- a/patient-service/pom.xml
+++ b/patient-service/pom.xml
@@ -62,6 +62,11 @@
             <groupId>com.h2database</groupId>
             <artifactId>h2</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.springdoc</groupId>
+            <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
+            <version>2.8.6</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/patient-service/src/main/java/com/xneshi/patientservice/controller/PatientController.java
+++ b/patient-service/src/main/java/com/xneshi/patientservice/controller/PatientController.java
@@ -4,6 +4,8 @@ import com.xneshi.patientservice.dto.PatientRequestDTO;
 import com.xneshi.patientservice.dto.PatientResponseDTO;
 import com.xneshi.patientservice.dto.validators.CreatePatientValidationGroup;
 import com.xneshi.patientservice.service.PatientService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.groups.Default;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
@@ -14,6 +16,7 @@ import java.util.UUID;
 
 @RestController
 @RequestMapping("/patients")
+@Tag(name = "Patient", description = "API for managing Patients")
 public class PatientController {
   private final PatientService patientService;
 
@@ -21,12 +24,15 @@ public class PatientController {
     this.patientService = patientService;
   }
 
+
   @GetMapping
+  @Operation(summary = "Get Patients")
   public ResponseEntity<List<PatientResponseDTO>> getPatients() {
     return ResponseEntity.ok().body(patientService.getPatients());
   }
 
   @PostMapping
+  @Operation(summary = "Post Patient")
   public ResponseEntity<PatientResponseDTO> createPatients(
       @Validated({Default.class, CreatePatientValidationGroup.class}) @RequestBody PatientRequestDTO patientRequestDTO
   ) {
@@ -34,6 +40,7 @@ public class PatientController {
   }
 
   @PutMapping("/{id}")
+  @Operation(summary = "Put Patient")
   public ResponseEntity<PatientResponseDTO> updatePatient(
       @PathVariable UUID id,
       @Validated({Default.class}) @RequestBody PatientResponseDTO patientResponseDTO
@@ -42,6 +49,7 @@ public class PatientController {
   }
 
   @DeleteMapping("/{id}")
+  @Operation(summary = "Delete Patient")
   public ResponseEntity<Void> deletePatient(
       @PathVariable UUID id
   ) {

--- a/patient-service/src/main/resources/application.yaml
+++ b/patient-service/src/main/resources/application.yaml
@@ -1,22 +1,23 @@
 spring:
   application:
     name: patient-service
-  h2:
-    console:
-      path: /h2-console
-      enabled: true
-  datasource:
-    url: jdbc:h2:mem:testdb
-    driver-class-name: org.h2.Driver
-    username: admin_viewer
-    password: password
-  jpa:
-    database-platform: org.hibernate.dialect.H2Dialect
-    hibernate:
-      ddl-auto: update
-  sql:
-    init:
-      mode: always
+#  h2:
+#    console:
+#      path: /h2-console
+#      enabled: true
+#  datasource:
+#    url: jdbc:h2:mem:testdb
+#    driver-class-name: org.h2.Driver
+#    username: admin_viewer
+#    password: password
+#  jpa:
+#    database-platform: org.hibernate.dialect.H2Dialect
+#    hibernate:
+#      ddl-auto: update
+#  sql:
+#    init:
+#      mode: always
+
 server:
   port: 4000
 


### PR DESCRIPTION
This pull request includes several significant changes to the `patient-service` project, focusing on containerization, API documentation, and configuration updates. Below is a summary of the most important changes:

### Containerization:
* Added a `Dockerfile` to build and run the `patient-service` application using Maven and OpenJDK.

### API Documentation:
* Added the `springdoc-openapi-starter-webmvc-ui` dependency to `pom.xml` for OpenAPI documentation support.
* Annotated `PatientController` with OpenAPI annotations to provide API documentation for endpoints. [[1]](diffhunk://#diff-2583f6cb713c2eb3e951e3959fac015b28ac35ac9ce8ed428b1dbfff453da3bcR7-R8) [[2]](diffhunk://#diff-2583f6cb713c2eb3e951e3959fac015b28ac35ac9ce8ed428b1dbfff453da3bcR19-R43) [[3]](diffhunk://#diff-2583f6cb713c2eb3e951e3959fac015b28ac35ac9ce8ed428b1dbfff453da3bcR52)

### Configuration Updates:
* Commented out the H2 database configuration in `application.yaml` to disable the in-memory database setup.